### PR TITLE
Add grab image action and camera availability diagnostics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(astra_camera)
 
-find_package(catkin REQUIRED actionlib camera_control_msgs camera_info_manager dynamic_reconfigure image_transport nodelet sensor_msgs roscpp message_generation)
+find_package(catkin REQUIRED actionlib camera_control_msgs camera_info_manager diagnostic_updater dynamic_reconfigure image_transport nodelet sensor_msgs roscpp message_generation)
 
 find_package(Boost REQUIRED COMPONENTS system thread)
 
@@ -68,7 +68,7 @@ generate_messages(
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES astra_wrapper
-  CATKIN_DEPENDS camera_info_manager actionlib camera_control_msgs dynamic_reconfigure image_transport nodelet sensor_msgs roscpp message_runtime
+  CATKIN_DEPENDS camera_info_manager actionlib camera_control_msgs diagnostic_updater dynamic_reconfigure image_transport nodelet sensor_msgs roscpp message_runtime
   #DEPENDS libastra
 )
 
@@ -188,7 +188,7 @@ install(FILES 56-orbbec-usb.rules
         DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 
-install(DIRECTORY scripts launch
+install(DIRECTORY launch scripts 
         DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(astra_camera)
 
-find_package(catkin REQUIRED camera_info_manager dynamic_reconfigure image_transport nodelet sensor_msgs roscpp message_generation)
+find_package(catkin REQUIRED actionlib camera_control_msgs camera_info_manager dynamic_reconfigure image_transport nodelet sensor_msgs roscpp message_generation)
 
 find_package(Boost REQUIRED COMPONENTS system thread)
 
@@ -68,7 +68,7 @@ generate_messages(
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES astra_wrapper
-  CATKIN_DEPENDS camera_info_manager dynamic_reconfigure image_transport nodelet sensor_msgs roscpp message_runtime
+  CATKIN_DEPENDS camera_info_manager actionlib camera_control_msgs dynamic_reconfigure image_transport nodelet sensor_msgs roscpp message_runtime
   #DEPENDS libastra
 )
 
@@ -184,7 +184,7 @@ install(FILES 56-orbbec-usb.rules
         DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 
-install(DIRECTORY scripts
+install(DIRECTORY scripts launch
         DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,10 @@ target_link_libraries(astra_list_devices astra_wrapper)
 
 add_executable(astra_test_wrapper test/test_wrapper.cpp )
 target_link_libraries(astra_test_wrapper astra_wrapper ${Boost_LIBRARIES})
+
+add_executable(action_image_client test/action_image_client.cpp)
+target_link_libraries(action_image_client ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+
 if (UNIX AND NOT APPLE)
   add_executable(astra_usb_reset src/usb_reset.c)
   set(ADDITIONAL_EXECUTABLES "astra_usb_reset")
@@ -149,7 +153,7 @@ add_library(libuvc_camera_nodelet src/libuvc_camera/nodelet.cpp
 target_link_libraries(libuvc_camera_nodelet ${libuvc_LIBRARIES} ${Boost_LIBRARIES} ${catkin_LIBRARIES})
 add_dependencies(libuvc_camera_nodelet ${PROJECT_NAME}_gencfg ${PROJECT_NAME}_generate_messages_cpp)
 
-install(TARGETS astra_wrapper astra_camera_nodelet astra_camera_node astra_list_devices astra_driver_lib ${ADDITIONAL_EXECUTABLES}
+install(TARGETS astra_wrapper action_image_client astra_camera_nodelet astra_camera_node astra_list_devices astra_driver_lib ${ADDITIONAL_EXECUTABLES}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/cfg/Astra.cfg
+++ b/cfg/Astra.cfg
@@ -36,6 +36,8 @@ gen.add("ir_mode", int_t, 0, "Video mode for IR camera", 5, 1, 17, edit_method =
 gen.add("color_mode", int_t, 0, "Video mode for color camera", 5, 1, 17, edit_method = output_mode_enum)
 gen.add("depth_mode", int_t, 0, "Video mode for depth camera", 5, 1, 17, edit_method = output_mode_enum)
 
+gen.add("always_active_rgb_stream", bool_t, 0, "Always active rgb stream", False)
+gen.add("always_active_depth_stream", bool_t, 0, "Always active depth stream", False)
 gen.add("depth_registration", bool_t, 0, "Depth data registration", True)
 gen.add("color_depth_synchronization", bool_t, 0, "Synchronization of color and depth camera", False)
 gen.add("auto_exposure", bool_t, 0, "Auto-Exposure", True)

--- a/include/astra_camera/astra_driver.h
+++ b/include/astra_camera/astra_driver.h
@@ -166,8 +166,8 @@ private:
 
   void advertiseROSTopics();
 
-  void imageConnectCb();
-  void depthConnectCb();
+  void imageConnectCb(bool grab_image_client_ = false);
+  void depthConnectCb(bool grab_image_client_ = false);
 
   bool getSerialCb(astra_camera::GetSerialRequest& req, astra_camera::GetSerialResponse& res);
   bool getDeviceTypeCb(astra_camera::GetDeviceTypeRequest& req, astra_camera::GetDeviceTypeResponse& res);

--- a/include/astra_camera/astra_driver.h
+++ b/include/astra_camera/astra_driver.h
@@ -254,6 +254,8 @@ private:
 
   bool color_depth_synchronization_;
   bool depth_registration_;
+  bool always_active_rgb_stream_;
+  bool always_active_depth_stream_;
 
   std::map<int, AstraVideoMode> video_modes_lookup_;
 

--- a/include/astra_camera/astra_driver.h
+++ b/include/astra_camera/astra_driver.h
@@ -75,6 +75,12 @@
 namespace astra_wrapper
 {
 
+typedef struct
+{
+  int exposure;
+  int gain;
+  bool auto_exposure;
+} CameraParameters;
 /**
  * @brief The ActionImageSyncer struct
  * @note When the change in a parameter of the camera is big, the camera is
@@ -281,8 +287,8 @@ private:
   void colorGrabImagesCallback(const camera_control_msgs::GrabImagesGoalConstPtr& goal);
   void depthGrabImagesCallback(const camera_control_msgs::GrabImagesGoalConstPtr& goal);
 
-  ///CameraParameters getCameraParameters() const;
-  ///void setCameraParameters(const CameraParameters &parameters);
+  CameraParameters getCameraParameters() const;
+  void setCameraParameters(const CameraParameters &parameters);
 
   ImageActionServerPtr color_action_server_;
   ImageActionServerPtr depth_action_server_;

--- a/package.xml
+++ b/package.xml
@@ -12,6 +12,7 @@
   <build_depend>actionlib</build_depend>
   <build_depend>camera_control_msgs</build_depend>
   <build_depend>camera_info_manager</build_depend>
+  <build_depend>diagnostic_updater</build_depend>
   <build_depend>git</build_depend>
   <build_depend>libudev-dev</build_depend>
   <build_depend>libusb-1.0-dev</build_depend>
@@ -26,6 +27,7 @@
   <run_depend>actionlib</run_depend>
   <run_depend>camera_control_msgs</run_depend>
   <run_depend>camera_info_manager</run_depend>
+  <run_depend>diagnostic_updater</run_depend>
   <run_depend>nodelet</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>sensor_msgs</run_depend>

--- a/package.xml
+++ b/package.xml
@@ -9,6 +9,8 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>actionlib</build_depend>
+  <build_depend>camera_control_msgs</build_depend>
   <build_depend>camera_info_manager</build_depend>
   <build_depend>git</build_depend>
   <build_depend>libudev-dev</build_depend>
@@ -21,6 +23,8 @@
   <build_depend>message_generation</build_depend>
   <build_depend>libuvc</build_depend>
 
+  <run_depend>actionlib</run_depend>
+  <run_depend>camera_control_msgs</run_depend>
   <run_depend>camera_info_manager</run_depend>
   <run_depend>nodelet</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>

--- a/src/astra_driver.cpp
+++ b/src/astra_driver.cpp
@@ -496,7 +496,7 @@ void AstraDriver::colorGrabImagesCallback(const camera_control_msgs::GrabImagesG
   }
 
   imageConnectCb(); // Connect (in case there are no subscribers)
-  ///CameraParameters old_parameters = getCameraParameters(); // Backup parameters
+  CameraParameters old_parameters = getCameraParameters(); // Backup parameters
 
   camera_control_msgs::GrabImagesResult result;
 
@@ -577,7 +577,7 @@ void AstraDriver::colorGrabImagesCallback(const camera_control_msgs::GrabImagesG
       break;
   }
 
-  ///setCameraParameters(old_parameters); // Restore parameters
+  setCameraParameters(old_parameters); // Restore parameters
   imageConnectCb();                    // Disconnect (in case there are no subscribers)
 }
 
@@ -642,6 +642,22 @@ void AstraDriver::depthGrabImagesCallback(const camera_control_msgs::GrabImagesG
   depth_action_server_->setSucceeded(result, "OK");
 
   depthConnectCb(); // Disconnect (in case there are no subscribers)
+}
+
+CameraParameters AstraDriver::getCameraParameters() const
+{
+  CameraParameters parameters;
+  parameters.exposure = device_->getIRExposure();
+  parameters.gain = device_->getIRGain();
+  parameters.auto_exposure = device_->getAutoExposure();
+  return parameters;
+}
+
+void AstraDriver::setCameraParameters(const CameraParameters &parameters)
+{
+  device_->setIRExposure(parameters.exposure);
+  device_->setIRGain(parameters.gain);
+  device_->setAutoExposure(parameters.auto_exposure);
 }
 
 void AstraDriver::applyConfigToOpenNIDevice()

--- a/test/action_image_client.cpp
+++ b/test/action_image_client.cpp
@@ -1,0 +1,66 @@
+#include <actionlib/client/simple_action_client.h>
+#include <camera_control_msgs/GrabImagesAction.h>
+#include <image_transport/image_transport.h>
+#include <ros/ros.h>
+
+typedef actionlib::SimpleActionClient<camera_control_msgs::GrabImagesAction>
+    ActionImageActionClient;
+typedef boost::shared_ptr<ActionImageActionClient> ActionImageActionClientPtr;
+
+class ActionImageClient {
+ public:
+  ActionImageClient();
+  void sendGoal();
+
+ private:
+  ros::NodeHandle nh_;
+  ActionImageActionClientPtr action_client_;
+  image_transport::ImageTransport it_;
+  image_transport::Publisher image_publisher_;
+};
+
+ActionImageClient::ActionImageClient() : it_(nh_) {
+  image_publisher_ = it_.advertise("debug_images", 1);
+
+  action_client_ = boost::make_shared<ActionImageActionClient>(
+      "camera/rgb/grab_images", true);
+  action_client_->waitForServer();
+}
+
+void ActionImageClient::sendGoal() {
+  camera_control_msgs::GrabImagesGoal goal;
+  // goal.exposure_auto = true;
+  goal.exposure_given = true;
+  goal.exposure_times.push_back(10);
+  goal.exposure_times.push_back(50);
+  goal.exposure_times.push_back(100);
+  goal.exposure_times.push_back(150);
+  goal.exposure_times.push_back(200);
+  goal.exposure_times.push_back(300);
+
+  action_client_->sendGoal(goal);
+  action_client_->waitForResult(ros::Duration(5));
+
+  if (action_client_->getState() == actionlib::SimpleClientGoalState::SUCCEEDED)
+    ROS_INFO_STREAM("ActionImageClient: Goal succeeded");
+  else
+    ROS_WARN_STREAM("ActionImageClient: Goal failed ("
+                    << action_client_->getState().state_
+                    << "): " << action_client_->getState().getText());
+
+  camera_control_msgs::GrabImagesResultConstPtr result =
+      action_client_->getResult();
+  for (size_t i = 0; i < result->images.size(); ++i) {
+    ros::Duration(1).sleep();
+    ROS_INFO_STREAM("Publishing image " << i << " with an exposure of "
+                                        << result->reached_exposure_times[i]);
+    image_publisher_.publish(result->images[i]);
+  }
+}
+
+int main(int argc, char **argv) {
+  ros::init(argc, argv, "action_image_client");
+  ActionImageClient client;
+  client.sendGoal();
+  return 0;
+}

--- a/test/action_image_client.cpp
+++ b/test/action_image_client.cpp
@@ -5,7 +5,7 @@
 
 typedef actionlib::SimpleActionClient<camera_control_msgs::GrabImagesAction>
     ActionImageActionClient;
-typedef boost::shared_ptr<ActionImageActionClient> ActionImageActionClientPtr;
+typedef boost::movelib::unique_ptr<ActionImageActionClient> ActionImageActionClientPtr;
 
 class ActionImageClient {
  public:
@@ -22,15 +22,15 @@ class ActionImageClient {
 ActionImageClient::ActionImageClient() : it_(nh_) {
   image_publisher_ = it_.advertise("debug_images", 1);
 
-  action_client_ = boost::make_shared<ActionImageActionClient>(
-      "camera/rgb/grab_images", true);
+  action_client_ = boost::movelib::make_unique<ActionImageActionClient>(
+      "rgb/grab_images", true);
   action_client_->waitForServer();
 }
 
 void ActionImageClient::sendGoal() {
   camera_control_msgs::GrabImagesGoal goal;
-  // goal.exposure_auto = true;
-  goal.exposure_given = true;
+  goal.exposure_auto = true;
+  // goal.exposure_given = true;
   goal.exposure_times.push_back(10);
   goal.exposure_times.push_back(50);
   goal.exposure_times.push_back(100);


### PR DESCRIPTION
This PR will add capabilities:

- grab depth and color image action

- publish `camera_availabilty` diagnostics

- reconnect with the camera if one gets disconnected

- use camera's serial number, provided as device_id, as a distinguishing method when multiple cameras are present