### PR TITLE
Move always_active_stream params update after all others are set

### DIFF
--- a/src/astra_driver.cpp
+++ b/src/astra_driver.cpp
@@ -491,22 +491,6 @@ void AstraDriver::configCb(Config &config, uint32_t level)
   color_time_offset_ = ros::Duration(config.color_time_offset);
   depth_time_offset_ = ros::Duration(config.depth_time_offset);
 
-  // Call Stream activators whenever the always_active parameters are changed
-  if (config.always_active_rgb_stream != always_active_rgb_stream_)
-  {
-    // keep rgb stream active, regardless of subscribers,
-    // to avoid delays and initialization issues
-    always_active_rgb_stream_ = config.always_active_rgb_stream;
-    imageConnectCb();
-  }
-  if (config.always_active_depth_stream != always_active_depth_stream_)
-  {
-    // keep depth stream active, regardless of subscribers,
-    // to avoid delays and initialization issues
-    always_active_depth_stream_ = config.always_active_depth_stream;
-    depthConnectCb();
-  }
-
   if (lookupVideoModeFromDynConfig(config.ir_mode, ir_video_mode_)<0)
   {
     ROS_ERROR("Undefined IR video mode received from dynamic reconfigure");
@@ -540,6 +524,22 @@ void AstraDriver::configCb(Config &config, uint32_t level)
   use_device_time_ = config.use_device_time;
 
   data_skip_ = config.data_skip+1;
+
+  // Call Stream activators whenever the always_active parameters are changed
+  if (config.always_active_rgb_stream != always_active_rgb_stream_)
+  {
+    // keep rgb stream active, regardless of subscribers,
+    // to avoid delays and initialization issues
+    always_active_rgb_stream_ = config.always_active_rgb_stream;
+    imageConnectCb();
+  }
+  if (config.always_active_depth_stream != always_active_depth_stream_)
+  {
+    // keep depth stream active, regardless of subscribers,
+    // to avoid delays and initialization issues
+    always_active_depth_stream_ = config.always_active_depth_stream;
+    depthConnectCb();
+  }
 
   applyConfigToOpenNIDevice();
 


### PR DESCRIPTION
When both parameters (_always_active_rgb/depth_stream_) were set to true during startup, the depth stream was crashing.
Error:
`[/gripper_depth_camera/gripper_depth_camera_nodelet_manager WARNING 1601635223.859837]: Reconfigure callback failed with exception void astra_wrapper::AstraDevice::setDepthVideoMode(const astra_wrapper::AstraVideoMode&) @ /home/toru/catkin_ws/src/ros_astra_camera/src/astra_device.cpp @ 679 : Couldn't set depth video mode: 
        Stream setProperty(3) failed`

This PR fixes it.